### PR TITLE
ci(github-actions): enforce explicit token permissions in workflows 🔒

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -25,15 +25,17 @@ jobs:
   release:
     name: Generate graphs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Generate graphs
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "graphs"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -25,16 +25,17 @@ jobs:
   release:
     name: Check status
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "response-time"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          GH_PAT: ${{ github.token }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -26,12 +26,15 @@ jobs:
   release:
     name: Setup Upptime
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       # Disabled: Upptime template regeneration rewrites pinned workflow SHAs
       # and breaks org policy that requires full-length commit pins.
       # - name: Update template
@@ -39,35 +42,34 @@ jobs:
       #   with:
       #     command: "update-template"
       #   env:
-      #     GH_PAT: ${{ secrets.GH_PAT || github.token }}
+      #     GH_PAT: ${{ github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "response-time"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          GH_PAT: ${{ github.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "readme"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}
       - name: Generate graphs
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: Graphs CI
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "site"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}
       - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
-          github_token: ${{ secrets.GH_PAT || github.token }}
+          github_token: ${{ github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "false"
           user_name: "Upptime Bot"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,22 +26,24 @@ jobs:
     name: Build and deploy site
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "site"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}
       - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
-          github_token: ${{ secrets.GH_PAT || github.token }}
+          github_token: ${{ github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "false"
           user_name: "Upptime Bot"

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -25,15 +25,17 @@ jobs:
   release:
     name: Generate README
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "readme"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -27,12 +27,14 @@ jobs:
   release:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       # Disabled: Upptime template regeneration rewrites pinned workflow SHAs
       # and breaks org policy that requires full-length commit pins.
       # - name: Update template
@@ -40,4 +42,4 @@ jobs:
       #   with:
       #     command: "update-template"
       #   env:
-      #     GH_PAT: ${{ secrets.GH_PAT || github.token }}
+      #     GH_PAT: ${{ github.token }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -25,13 +25,15 @@ jobs:
   release:
     name: Deploy updates
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Update code
         uses: upptime/updates@c8be3a2281e37dfb3211b7cd8f847b014e551634 # master
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+          GH_PAT: ${{ github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -25,16 +25,17 @@ jobs:
   release:
     name: Check status
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{ github.token }}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "update"
         env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          GH_PAT: ${{ github.token }}


### PR DESCRIPTION
- Removes the need of a static GitHub PAT and relies instead on ephemeral workflow tokens.
- explicitly sets `contents: write` permission for all jobs
- adds `actions: write` permission for `setup.yml` job to allow workflow dispatch
- standardizes usage of `github.token` for all actions
- removes redundant `secrets.gh_pat` fallback from workflow configurations
- removes unused `secrets_context` environment variable
