### PR TITLE
feat: add barn api, barn bff and debug tool

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -48,6 +48,165 @@ sites:
       - "Referer: https://swap.cow.fi/"
       - "affiliate: 609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb"
 
+  - name: Debug Tool
+    url: https://debug.cow.fi/api/health
+
+  - name: Barn Debug Tool
+    url: https://debug.barn.cow.fi/api/health
+
+  - name: Barn Quote API Mainnet # WETH - USDC
+    method: POST
+    url: https://barn.api.cow.fi/mainnet/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        "buyToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "from": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+      }
+
+  - name: Barn Quote API Gnosis Chain # WXDAI - USDC
+    method: POST
+    url: https://barn.api.cow.fi/xdai/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000000",
+        "sellToken": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+        "buyToken": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+        "from": "0xC9Fe2D32E96Bb364c7d29f3663ed3b27E30767bB"
+      }
+
+  - name: Barn Quote API Arbitrum One # WETH - USDC
+    method: POST
+    url: https://barn.api.cow.fi/arbitrum_one/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        "buyToken": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+
+  - name: Barn Quote API Base # WETH - USDC
+    method: POST
+    url: https://barn.api.cow.fi/base/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0x4200000000000000000000000000000000000006",
+        "buyToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+
+  - name: Barn Quote API Avalanche # WAVAX - USDC
+    method: POST
+    url: https://barn.api.cow.fi/avalanche/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+        "buyToken": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+        "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+
+  - name: Barn Quote API Polygon # WPOL - USDC
+    method: POST
+    url: https://barn.api.cow.fi/polygon/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270", 
+        "buyToken": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+
+  - name: Barn Quote API BNB # USDT - WBNB
+    method: POST
+    url: https://barn.api.cow.fi/bnb/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0x55d398326f99059ff775485246999027b3197955", 
+        "buyToken": "0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
+        "from": "0x21a31Ee1afC51d94C2eFcCAa2092aD1028285549"
+      }  
+
+  - name: Barn Quote API LINEA # USDT - USDC
+    method: POST
+    url: https://barn.api.cow.fi/linea/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000",
+        "sellToken": "0xa219439258ca9da29e9cc4ce5596924745e12b93", 
+        "buyToken": "0x176211869ca2b568f2a7d4ee941e073a821ee1ff",
+        "from": "0x5dc74003c0a9d08eb750b10ed5b02fa7d58d4d1e"
+      }
+
+  - name: Barn Quote API Ink # WETH - USDC
+    method: POST
+    url: https://barn.api.cow.fi/ink/api/v1/quote
+    headers: ["Content-Type: application/json"]
+    body: |
+      {
+        "kind": "sell",
+        "sellAmountBeforeFee": "10000000000000000000",
+        "sellToken": "0x4200000000000000000000000000000000000006",
+        "buyToken": "0x0200C29006150606B650577BBE7B6248F58470c1",
+        "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+      }
+
+  - name: Barn BFF - Slippage Tolerance (mainnet) # COW - WETH
+    url: https://bff.barn.cow.fi/1/markets/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/slippageTolerance
+
+  - name: Barn BFF - Slippage Tolerance (Gnosis Chain) # COW - WXDAI
+    url: https://bff.barn.cow.fi/100/markets/0x177127622c4a00f3d409b75571e12cb3c8973d3c-0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/slippageTolerance
+
+  - name: Barn BFF - Slippage Tolerance (Arbitrum One) # COW - WETH
+    url: https://bff.barn.cow.fi/42161/markets/0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04-0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/slippageTolerance
+
+  - name: Barn BFF - Slippage Tolerance (Base) # COW - WETH
+    url: https://bff.barn.cow.fi/8453/markets/0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69-0x4200000000000000000000000000000000000006/slippageTolerance
+
+  - name: Barn BFF - Slippage Tolerance (Avalanche) # USDT - WAVAX
+    url: https://bff.barn.cow.fi/43114/markets/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7-0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7/slippageTolerance
+
+  - name: Barn BFF - Slippage Tolerance (Polygon) # DAI - WPOL
+    url: https://bff.barn.cow.fi/137/markets/0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063-0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/slippageTolerance
+
+  - name: Barn BFF - USD Price (mainnet) # WETH
+    url: https://bff.barn.cow.fi/1/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/usdPrice
+
+  - name: Barn BFF - USD Price (Gnosis Chain) # WXDAI
+    url: https://bff.barn.cow.fi/100/tokens/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/usdPrice
+
+  - name: Barn BFF - USD Price (Arbitrum One) # WETH
+    url: https://bff.barn.cow.fi/42161/tokens/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/usdPrice
+
+  - name: Barn BFF - USD Price (Base) # WETH
+    url: https://bff.barn.cow.fi/8453/tokens/0x4200000000000000000000000000000000000006/usdPrice
+
+  - name: Barn BFF - USD Price (Avalanche) # WAVAX
+    url: https://bff.barn.cow.fi/43114/tokens/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7/usdPrice
+
+  - name: Barn BFF - USD Price (Polygon) # WPOL
+    url: https://bff.barn.cow.fi/137/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/usdPrice
+
 status-website:
   cname: periphery.status.cow.fi
   baseUrl: /


### PR DESCRIPTION
We recently had downtime in:
1. barn.api.cow.fi - [see slack thread](https://nomevlabs.slack.com/archives/C036PMLUPQF/p1779882432065469)
2. debug.barn.cow.fi - [see slack thread](https://nomevlabs.slack.com/archives/C036G0J90BU/p1779949470008809)

Review only the first commit: 74a1ffb

> [!WARNING]
> /api/health on debug tool is giving 401 and that is coming from ingress which most likely won't catch downtime in debug

> [!NOTE]
> uptime and uptime-periphery have different slack webhook setups:
> 
>  Same:                                                                                                                                              
>  - Both have .github/workflows/slack-ci-failures.yml                                                                                                
>  - Both notify Slack on workflow failure                                                                                                            
>  - Both use secret: NOTIFICATION_SLACK_WEBHOOK_URL                                                                                                  
>                                                                                                                                                     
>  Different:                                                                                                                                         
>  - uptime-periphery/.upptimerc.yml has:                                                                                                             
>    ```yml                                                                                                                                           
>      notifications:                                                                                                                                 
>        - type: slack                                                                                                                                
>          webhook-url: $SLACK_WEBHOOK_URL                                                                                                            
>    ```                                                                                                                                              
>  - main uptime/.upptimerc.yml does not have that Upptime notification block.    